### PR TITLE
marshallers cleanup

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -12,7 +12,6 @@ import (
 	"syreclabs.com/go/faker"
 
 	cache "github.com/vkuptcov/go-redis-cache/v8"
-	"github.com/vkuptcov/go-redis-cache/v8/internal/marshaller"
 	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
 )
 
@@ -31,7 +30,7 @@ func (st *BaseCacheSuite) SetupSuite() {
 
 	st.ctx = context.Background()
 
-	st.marshaller = marshaller.NewMarshaller(&marshallers.JSONMarshaller{})
+	st.marshaller = marshallers.NewMarshaller(&marshallers.JSONMarshaller{})
 
 	st.cache = cache.NewCache(cache.Options{
 		Redis:      st.client,

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/go-redis/redis/v8"
 	cache "github.com/vkuptcov/go-redis-cache/v8"
 	"github.com/vkuptcov/go-redis-cache/v8/cachekeys"
-	"github.com/vkuptcov/go-redis-cache/v8/internal/marshaller"
 	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
 )
 
@@ -25,7 +24,7 @@ func Example_saveAndGetUser() {
 
 	cacheInst := cache.NewCache(cache.Options{
 		Redis:      client,
-		Marshaller: marshaller.NewMarshaller(&marshallers.JSONMarshaller{}),
+		Marshaller: marshallers.NewMarshaller(&marshallers.JSONMarshaller{}),
 	})
 
 	user := &User{
@@ -94,7 +93,7 @@ func Example_saveSeveralUsersAndLoadInSlice() {
 
 	cacheInst := cache.NewCache(cache.Options{
 		Redis:      client,
-		Marshaller: marshaller.NewMarshaller(&marshallers.JSONMarshaller{}),
+		Marshaller: marshallers.NewMarshaller(&marshallers.JSONMarshaller{}),
 	})
 
 	keyByID := func(id string) string {
@@ -155,7 +154,7 @@ func Example_loadUsers() {
 
 	cacheInst := cache.NewCache(cache.Options{
 		Redis:      client,
-		Marshaller: marshaller.NewMarshaller(&marshallers.JSONMarshaller{}),
+		Marshaller: marshallers.NewMarshaller(&marshallers.JSONMarshaller{}),
 	})
 
 	keyByID := func(id string) string {

--- a/exportedtypes.go
+++ b/exportedtypes.go
@@ -2,9 +2,10 @@ package cache
 
 import (
 	"github.com/vkuptcov/go-redis-cache/v8/internal"
+	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
 )
 
-type Marshaller internal.Marshaller
+type Marshaller marshallers.Marshaller
 
 type Item = internal.Item
 

--- a/internal/options.go
+++ b/internal/options.go
@@ -1,6 +1,10 @@
 package internal
 
-import "time"
+import (
+	"time"
+
+	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
+)
 
 type Options struct {
 	Redis Rediser
@@ -9,7 +13,7 @@ type Options struct {
 	// 1 hour by default
 	DefaultTTL time.Duration
 
-	Marshaller Marshaller
+	Marshaller marshallers.Marshaller
 
 	AbsentKeysLoader func(absentKeys ...string) (interface{}, error)
 

--- a/marshallers/basemarshaller.go
+++ b/marshallers/basemarshaller.go
@@ -1,17 +1,15 @@
-package marshaller
+package marshallers
 
 import (
 	"reflect"
 	"strconv"
-
-	"github.com/vkuptcov/go-redis-cache/v8/internal"
 )
 
 type baseMarshaller struct {
-	customMarshaller internal.Marshaller
+	customMarshaller Marshaller
 }
 
-func NewMarshaller(customMarshaller internal.Marshaller) internal.Marshaller {
+func NewMarshaller(customMarshaller Marshaller) Marshaller {
 	return &baseMarshaller{customMarshaller: customMarshaller}
 }
 

--- a/marshallers/basemarshaller_test.go
+++ b/marshallers/basemarshaller_test.go
@@ -1,4 +1,4 @@
-package marshaller
+package marshallers
 
 import (
 	"math"
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
-	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
 )
 
 type structureToSerialize struct {
@@ -21,7 +19,7 @@ type MarshalUnMarshalSuite struct {
 
 func (st *MarshalUnMarshalSuite) SetupSuite() {
 	st.marshaller = &baseMarshaller{
-		customMarshaller: &marshallers.JSONMarshaller{},
+		customMarshaller: &JSONMarshaller{},
 	}
 }
 

--- a/marshallers/jsonmarshaller.go
+++ b/marshallers/jsonmarshaller.go
@@ -2,8 +2,6 @@ package marshallers
 
 import (
 	"encoding/json"
-
-	"github.com/vkuptcov/go-redis-cache/v8/internal"
 )
 
 type JSONMarshaller struct{}
@@ -16,4 +14,4 @@ func (t *JSONMarshaller) Unmarshal(data []byte, dst interface{}) error {
 	return json.Unmarshal(data, dst)
 }
 
-var _ internal.Marshaller = &JSONMarshaller{}
+var _ Marshaller = &JSONMarshaller{}

--- a/marshallers/marshaller.go
+++ b/marshallers/marshaller.go
@@ -1,4 +1,4 @@
-package internal
+package marshallers
 
 type Marshaller interface {
 	Marshal(value interface{}) ([]byte, error)

--- a/scenarios/common_test.go
+++ b/scenarios/common_test.go
@@ -10,7 +10,6 @@ import (
 
 	cache "github.com/vkuptcov/go-redis-cache/v8"
 	"github.com/vkuptcov/go-redis-cache/v8/cachekeys"
-	"github.com/vkuptcov/go-redis-cache/v8/internal/marshaller"
 	"github.com/vkuptcov/go-redis-cache/v8/marshallers"
 )
 
@@ -58,7 +57,7 @@ func (st *BaseCacheSuite) SetupSuite() {
 
 	st.ctx = context.Background()
 
-	st.marshaller = marshaller.NewMarshaller(&marshallers.JSONMarshaller{})
+	st.marshaller = marshallers.NewMarshaller(&marshallers.JSONMarshaller{})
 
 	st.cache = cache.NewCache(cache.Options{
 		Redis:      st.client,


### PR DESCRIPTION
marshallers moved into an upper-level package in order to make its constructor available for the library users